### PR TITLE
chore: suggestions

### DIFF
--- a/ERCS/erc-7895.md
+++ b/ERCS/erc-7895.md
@@ -2,7 +2,7 @@
 eip: 7895
 title: API for hierarchical accounts
 description: Adds JSON-RPC method for requesting a universal wallet to create or track another account that it owns
-author: Wilson Cusack (@wilsoncusack), Jake Feldman (@jakefeldman), Montana Wong (@montycheese), Felix Zhang (@fan-zhang-sv)
+author: Wilson Cusack (@wilsoncusack), Jake Feldman (@jakefeldman), Montana Wong (@montycheese), Felix Zhang (@fan-zhang-sv), Jake Moxey (@jxom)
 discussions-to: https://ethereum-magicians.org/t/wallet-addsubaccount/23013
 status: Draft
 type: Standards Track
@@ -51,8 +51,8 @@ type DeployedAccount = {
 type CreateAccount = {
   type: "create";
   keys: { 
+    publicKey: "0x...";
     type: "address" | "p256" | "webcrypto-p256" |  "webauthn-p256";
-    key: "0x...";
   }[];
 }
 
@@ -103,8 +103,8 @@ type Parameters = {
   address: never;
   // Required: keys of the account to be created
   keys: { 
+    publicKey: "0x...";
     type: "address" | "p256" | "webcrypto-p256" |  "webauthn-p256";
-    key: "0x...";
   }[];
   factory: never;
   factoryData: never;
@@ -150,7 +150,9 @@ type Parameters = {
 
 This ERC conforms to ERC-7846 which includes [ERC-5792](./erc-5792.md) capabilities specification and introduces two new capabilities for `wallet_connect`. 
 
-##### addSubAccount 
+##### `addSubAccount`
+
+Adds a sub-account to the universal account.
 
 ```typescript
 type Request = {
@@ -158,23 +160,15 @@ type Request = {
     account: CreateAccount | DeployedAccount | UndeployedAccount;
   }
 }
-
-type Response = {
-  addSubAccount: {
-    address: `0x${string}`;
-  }
-}
 ```
 
-##### `getSubAccounts`
+##### `subAccounts`
+
+Fetches all sub-accounts of the universal account (including any added ones).
 
 ```typescript
-type Request = {
-  getSubAccounts: boolean;
-}
-
 type Response = {
-  getSubAccounts: {
+  subAccounts: {
     address: `0x${string}`;
     factory?: `0x${string}`;
     factoryData?: `0x${string}`;


### PR DESCRIPTION
Suggesting a couple of changes to remove duplication & redundancy.

1. Rename `keys.key` to `keys.publicKey`. Rationale: Feels a bit odd to have duplicate "key" keywords.
2. Remove `addSubAccount` from `wallet_connect` response capabilities. Rationale: We can extract a created sub-account from the `getSubAccounts` response capability.
3. Remove `getSubAccounts` from `wallet_connect` request capabilities. Rationale: I think wallets should just respond with their sub-accounts so that a developer doesn't need to explicitly pass this (would make life easier for tooling).
4. Rename `getSubAccounts` to just `subAccounts`. Rationale: More consistent with existing keywords such as `accounts`.